### PR TITLE
.eslintrcに対するlintエラーを解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "^9.0.0",
     "@nuxtjs/eslint-module": "^3.0.2",
+    "@typescript-eslint/eslint-plugin": "^5.14.0",
+    "@typescript-eslint/parser": "^5.14.0",
     "eslint": "^8.11.0",
-    "nuxt3": "latest"
+    "nuxt3": "latest",
+    "typescript": "^4.6.2"
   },
   "dependencies": {
     "bulma": "^0.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5229,6 +5229,11 @@ type-fest@^2.11.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.12.0.tgz#ce342f58cab9114912f54b493d60ab39c3fc82b6"
   integrity sha512-Qe5GRT+n/4GoqCNGGVp5Snapg1Omq3V7irBJB3EaKsp7HWDo5Gv2d/67gfNyV+d5EXD+x/RF5l1h4yJ7qNkcGA==
 
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
 ufo@^0.7.11, ufo@^0.7.9:
   version "0.7.11"
   resolved "https://registry.yarnpkg.com/ufo/-/ufo-0.7.11.tgz#17defad497981290383c5d26357773431fdbadcb"


### PR DESCRIPTION
## lintエラー
```
$ yarn lint
yarn run v1.22.17
$ eslint --ext .ts,.js,.vue --ignore-path .gitignore .

Oops! Something went wrong! :(

ESLint: 8.11.0

Error: Failed to load plugin '@typescript-eslint' declared in '.eslintrc » @nuxtjs/eslint-config-typescript': Cannot find module 'typescript'
```

## 対応
`typescript-eslint` をinstall
https://www.npmjs.com/package/@typescript-eslint/eslint-plugin